### PR TITLE
Update catboxThumbnails.user.js

### DIFF
--- a/catbox/catboxThumbnails.user.js
+++ b/catbox/catboxThumbnails.user.js
@@ -23,7 +23,8 @@
             const fixedExt = ext.toLowerCase()
                 .replace(/^pn$/, 'png')
                 .replace(/^jpe$/, 'jpeg')
-                .replace(/^jp$/, 'jpg');
+                .replace(/^jp$/, 'jpg')
+                .replace(/^web$/, 'webp');; // Add webp
 
             return '.' + fixedExt + (rest || '');
         });
@@ -68,7 +69,7 @@
     document.body.appendChild(toggleButton);
 
     // Regex to handle URLs and any character sequences up to 'g' after partial extensions
-    const urlRegex = /https:\/\/(?:files\.catbox\.moe|litter\.catbox\.moe)\/\S+?\.(pn.*?g|jpe.*?g|jp.*?g)/gi;
+    const urlRegex = /https:\/\/(?:files\.catbox\.moe|litter\.catbox\.moe)\/\S+?\.(web.*?p|pn.*?g|jpe.*?g|jp.*?g)/gi; // Add webp
 
     document.querySelectorAll('blockquote').forEach(blockquote => {
         let text = blockquote.innerHTML;

--- a/catbox/catboxThumbnails.user.js
+++ b/catbox/catboxThumbnails.user.js
@@ -14,12 +14,18 @@
     let showThumbnails = false;
 
     const createImageLink = (url) => {
-        // Correct the URL to ensure it ends with the proper extension
-        url = url.replace(/<wbr>/gi, ''); // Remove any <wbr> tags
-        url = url.replace(/(pn|jpe|jp).*?g/gi, (match) => {
-            if (match.startsWith('pn')) return 'png';
-            if (match.startsWith('jpe')) return 'jpeg';
-            if (match.startsWith('jp')) return 'jpg';
+        // Remove any <wbr> tags first
+        url = url.replace(/<wbr>/gi, '');
+
+        // Fix file extension in the URL
+        url = url.replace(/\.([^.?#]+)([?#].*)?$/, (match, ext, rest) => {
+            // Fix common extensions
+            const fixedExt = ext.toLowerCase()
+                .replace(/^pn$/, 'png')
+                .replace(/^jpe$/, 'jpeg')
+                .replace(/^jp$/, 'jpg');
+
+            return '.' + fixedExt + (rest || '');
         });
 
         let link = document.createElement('a');


### PR DESCRIPTION
The original code mistakenly altered characters beyond the extension (e.g., converting nu2jpy.png to nu2jpg) because its regex scanned the entire URL for partial matches. The revised solution uses /\.([^.?#]+)([?#].*)?$/ to isolate and modify only the extension (the part after the last . before ? or #), ensuring parameters/fragments (like ?width=200) remain intact. It then precisely maps truncated extensions (pn → png, jpe → jpeg, jp → jpg) while leaving valid extensions unchanged.
![aa](https://github.com/user-attachments/assets/655e9f39-d887-4d50-879e-a5070efcc9bf)
